### PR TITLE
Added support for authorization code grant flow

### DIFF
--- a/R/token.R
+++ b/R/token.R
@@ -15,7 +15,7 @@
 #'   See \url{https://dev.fitbit.com/reference/web-api/basics/#language} for more details.
 #'
 #' @export
-oauth_token <- function(key=NULL, secret=NULL, callback=NULL, locale=NULL, language=NULL, use_basic_auth=TRUE)
+oauth_token <- function(key=NULL, secret=NULL, callback=NULL, locale=NULL, language=NULL, use_basic_auth=TRUE, auth_page_query_params=NULL)
 {
   #Load key automatically from global or environmnt variable
   keys <- tidy_key_and_secret(key, secret)
@@ -35,7 +35,7 @@ oauth_token <- function(key=NULL, secret=NULL, callback=NULL, locale=NULL, langu
   endpoint <- create_endpoint()
   myapp <- httr::oauth_app("r-package", key=keys$key, secret=keys$secret, redirect_uri=callback)
   list(
-    token=httr::oauth2.0_token(endpoint, myapp, scope=scope, use_basic_auth=use_basic_auth, config_init=c(header, content_type), cache=FALSE),
+    token=httr::oauth2.0_token(endpoint, myapp, scope=scope, use_basic_auth=use_basic_auth, config_init=c(header, content_type), cache=FALSE, auth_page_query_params=auth_page_query_params),
     locale=locale,
     language=language
   )

--- a/R/token.R
+++ b/R/token.R
@@ -15,7 +15,7 @@
 #'   See \url{https://dev.fitbit.com/reference/web-api/basics/#language} for more details.
 #'
 #' @export
-oauth_token <- function(key=NULL, secret=NULL, callback=NULL, locale=NULL, language=NULL)
+oauth_token <- function(key=NULL, secret=NULL, callback=NULL, locale=NULL, language=NULL, use_basic_auth=TRUE)
 {
   #Load key automatically from global or environmnt variable
   keys <- tidy_key_and_secret(key, secret)
@@ -35,7 +35,7 @@ oauth_token <- function(key=NULL, secret=NULL, callback=NULL, locale=NULL, langu
   endpoint <- create_endpoint()
   myapp <- httr::oauth_app("r-package", key=keys$key, secret=keys$secret, redirect_uri=callback)
   list(
-    token=httr::oauth2.0_token(endpoint, myapp, scope=scope, config_init=c(header, content_type), cache=FALSE),
+    token=httr::oauth2.0_token(endpoint, myapp, scope=scope, use_basic_auth=use_basic_auth, config_init=c(header, content_type), cache=FALSE),
     locale=locale,
     language=language
   )

--- a/R/token.R
+++ b/R/token.R
@@ -11,11 +11,16 @@
 #'   Possible values: c(en_AU | fr_FR | de_DE | ja_JP | en_NZ | es_ES | en_GB | en_US)
 #' @param language The unit systems of values.
 #'   Possible values: c(en_US | en_GB | other )
+#' @param use_basic_auth Fitbit currently uses HTTR's basic_auth setting (so set to TRUE)
+#' @param auth_page_query_params Additional URI Paramters, e.g.
+#'   expires_in: c(86400, 604800, 2592000, 31536000)
+#'   prompt: c("none", "consent", "login", "login consent")
+#'   see https://dev.fitbit.com/build/reference/web-api/oauth2/ for full list
 #' @details
 #'   See \url{https://dev.fitbit.com/reference/web-api/basics/#language} for more details.
 #'
 #' @export
-oauth_token <- function(key=NULL, secret=NULL, callback=NULL, locale=NULL, language=NULL, use_basic_auth=TRUE, auth_page_query_params=NULL)
+oauth_token <- function(key=NULL, secret=NULL, callback=NULL, locale=NULL, language=NULL, use_basic_auth=TRUE, auth_page_query_params=list(prompt="none"))
 {
   #Load key automatically from global or environmnt variable
   keys <- tidy_key_and_secret(key, secret)
@@ -35,7 +40,7 @@ oauth_token <- function(key=NULL, secret=NULL, callback=NULL, locale=NULL, langu
   endpoint <- create_endpoint()
   myapp <- httr::oauth_app("r-package", key=keys$key, secret=keys$secret, redirect_uri=callback)
   list(
-    token=httr::oauth2.0_token(endpoint, myapp, scope=scope, use_basic_auth=use_basic_auth, config_init=c(header, content_type), cache=FALSE, auth_page_query_params=auth_page_query_params),
+    token=httr::oauth2.0_token(endpoint, myapp, scope=scope, use_basic_auth=use_basic_auth, config_init=c(header, content_type), cache=FALSE, query_authorize_extra=auth_page_query_params),
     locale=locale,
     language=language
   )


### PR DESCRIPTION
Specifically:

**1) added ability to specify use_basic_auth**
use_basic_auth (for httr::oauth2.0_token) must be set to TRUE for Fitbit oauth2.0 authorization code grant flow (as per Fitbit API) currently use_basic_auth defaults to FALSE (which is fine I think for implicit code grant flow). Since some users may want to use authorization code grant flow for their applications exposing this so users can change this and use this library is helpful.

**2) added ability to specify query parameters for Fitbit authentication page**
_see [httr#503](https://github.com/r-lib/httr/pull/503)_
The httr library was recently updated to support the ability to pass down URLquery parameters to the initial oauth2.0 authorization page. This is useful for the for defining additional URI parameters in the authorization code grant flow (such as token expiration duration, ability to force authorization page/consent and others - see Authorization Page @ https://dev.fitbit.com/build/reference/web-api/oauth2/) that must be appended to the initial authorization URL.


