### PR TITLE
Force date input to be character

### DIFF
--- a/R/common.R
+++ b/R/common.R
@@ -71,10 +71,10 @@ extract_content <- function(response)
 }
 
 format_date <- function(date){
-  if(lubridate::is.Date(date)){
-    format(date, "%Y-%m-%d")
-  }else{
-    date
+  if (lubridate::is.Date(date)){
+    as.character(format(date, "%Y-%m-%d"))
+  } else{
+    as.character(date)
   }
 }
 


### PR DESCRIPTION
When passing a date in `Date` class, some functions crashed with the following error:
```
Error in if (date != "" && period != "") { : 
  missing value where TRUE/FALSE needed
```